### PR TITLE
Node LTS using fnm

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ zsh <(curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/main/copy-c
 
 ## Setup git
 
-Please enter the requested inputs and press `Enter` when asked about which file to save key and your passphrase. By simply pressing `Enter` the default settings will be used.
+Please enter the requested inputs and press `Enter` when asked about which file to save key and your passphrase. By simply pressing `Enter` the default settings will be used. Choose `ssh` as your preferred connection method. Login and authenticate with the browser. (The device code is found in the Terminal.)
 
 ```sh
 zsh <(curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/main/setup-git)

--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 ## What does this setup do?
 
-- Install Homebrew for software installation
-- Install software: iTerm, Slack, Firefox Developer Edition, Visual Studio Code, Zoom, Postman, Rectangle
-- Install command line tools: zsh, git, antigen, zsh-completions, exa, fasd, fzf
-- Install the font "Fira Code"
-- Add shell-integration for iTerm
-- Setup zsh with a powerful prompt, aliases and convenient shortcuts
-- Create git configuration with user name and email
-- Create ssh key and add the passphrase to the macOS keychain
+- Install Homebrew and [common command line tools](install-brew#L12)
+- Setup [zsh with a powerful prompt, aliases and convenient shortcuts](https://github.com/neuefische/zsh-setup/blob/main/copy-configs)
+- Add [shell-integration for iTerm](https://github.com/neuefische/zsh-setup/blob/main/setup-iterm)
+- Setup a [git user and create and link an ssh key for GitHub](https://github.com/neuefische/zsh-setup/blob/main/setup-git)
+- Install [common macOS software](https://github.com/neuefische/zsh-setup/blob/main/install-apps#L5) for developers
+- Install [MongoDB](https://github.com/neuefische/zsh-setup/blob/main/install-mongo) (community-edition)
 
 ## How to run the setup
 

--- a/configs/.prettierrc
+++ b/configs/.prettierrc
@@ -1,6 +1,6 @@
 {
   "arrowParens": "avoid",
-  "semi": false,
+  "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",

--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -52,3 +52,6 @@ setopt extendedglob
 
 # Enable fuzzy backwards search
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+
+# Setup fnm (fast node manager)
+eval "$(fnm env --use-on-cd)"

--- a/copy-configs
+++ b/copy-configs
@@ -1,8 +1,8 @@
 #!/usr/bin/env zsh
 # Copy configuration files
-curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/master/configs/.zshrc > ~/.zshrc;
-curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/master/configs/.aliases > ~/.aliases;
-curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/master/configs/.p10k.zsh > ~/.p10k.zsh;
+curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/main/configs/.zshrc > ~/.zshrc;
+curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/main/configs/.aliases > ~/.aliases;
+curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/main/configs/.p10k.zsh > ~/.p10k.zsh;
 mkdir ~/.prettier;
-curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/master/configs/.prettierrc > ~/.prettier/.prettierrc;
-curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/master/configs/.prettierignore > ~/.prettier/.prettierignore;
+curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/main/configs/.prettierrc > ~/.prettier/.prettierrc;
+curl -s https://raw.githubusercontent.com/neuefische/zsh-setup/main/configs/.prettierignore > ~/.prettier/.prettierignore;

--- a/install-apps
+++ b/install-apps
@@ -2,6 +2,6 @@
 # Install macOS apps
 brew tap homebrew/cask-fonts && brew install --cask font-fira-code &&
 brew tap homebrew/cask-versions && brew install --cask firefox-developer-edition --lang=en-US &&
-for x in authy zoom iterm2 slack visual-studio-code rectangle mongodb-compass quicklook-csv quicklook-json webpquicklook; do brew install --cask $x; done &&
+for x in authy iterm2 visual-studio-code rectangle mongodb-compass quicklook-csv quicklook-json webpquicklook; do brew install --cask $x; done &&
 echo "------------------------\n\nInstalled apps:\n---------------\n" &&
 brew list --cask -1

--- a/install-apps
+++ b/install-apps
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 # Install macOS apps
 brew tap homebrew/cask-fonts && brew install --cask font-fira-code &&
-brew tap homebrew/cask-versions && brew install --cask firefox-developer-edition --lang=en-US &&
 for x in authy iterm2 visual-studio-code rectangle mongodb-compass quicklook-csv quicklook-json webpquicklook; do brew install --cask $x; done &&
 echo "------------------------\n\nInstalled apps:\n---------------\n" &&
-brew list --cask -1
+brew list --cask -1 &&
+brew tap homebrew/cask-versions && brew install --cask firefox-developer-edition --lang=en-US

--- a/install-brew
+++ b/install-brew
@@ -9,7 +9,7 @@ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/`echo $USER`/.zprofil
 eval "$(/opt/homebrew/bin/brew shellenv)";
 fi
 
-for x in go gh zsh git antigen zsh-completions exa fasd tree bat httpie lynx; do brew install $x; done;
+for x in go gh zsh git antigen zsh-completions exa fasd tree bat httpie lynx node; do brew install $x; done;
 brew install fzf && $(brew --prefix)/opt/fzf/install &&
 echo "------------------------\n\nInstalled formulae:\n-------------------\n" &&
 brew list --formulae -1

--- a/install-brew
+++ b/install-brew
@@ -9,7 +9,15 @@ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/`echo $USER`/.zprofil
 eval "$(/opt/homebrew/bin/brew shellenv)";
 fi
 
-for x in go gh zsh git antigen zsh-completions exa fasd tree bat httpie lynx node; do brew install $x; done;
+for x in go gh zsh git antigen zsh-completions exa fasd tree bat httpie lynx fnm; do brew install $x; done;
 brew install fzf && $(brew --prefix)/opt/fzf/install &&
 echo "------------------------\n\nInstalled formulae:\n-------------------\n" &&
 brew list --formulae -1
+
+echo "Setting up Node LTS\n";
+eval "$(fnm env --use-on-cd)";
+fnm install lts-latest;
+fnm alias lts-latest default;
+fnm use default;
+echo "Installed Node Version:";
+node -v;

--- a/install-mongo
+++ b/install-mongo
@@ -5,10 +5,10 @@ arch_name="$(uname -m)";
 if [ "${arch_name}" = "arm64" ]; then
     echo "\n\n--------------\nYou have a Mac with M1, so I'll install Rosetta for mongodb\n\n"
     /usr/sbin/softwareupdate --install-rosetta --agree-to-license;
-    arch -arm64 brew install mongodb-community@4.4;
+    arch -arm64 brew install mongodb-community@5.0;
     brew services start mongodb/brew/mongodb-community;
 else
     echo "\n\n--------------\nYou have a Mac with Intel processor\n\n"
-    brew install mongodb-community@4.4;
-    brew services start mongodb-community@4.4;
+    brew install mongodb-community@5.0;
+    brew services start mongodb-community@5.0;
 fi

--- a/setup-git
+++ b/setup-git
@@ -9,5 +9,6 @@ ssh-keygen -t ed25519 -C $email;
 eval "$(ssh-agent -s)";
 echo "Host *\n    AddKeysToAgent yes\n    UseKeychain yes\n    IdentityFile ~/.ssh/id_ed25519" > ~/.ssh/config;
 ssh-add -K ~/.ssh/id_ed25519;
+ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts # add github.com to the list of known hosts
 echo "------------------------\n\nPlease follow the instructions:\n-------------------\n" &&
 gh auth login;

--- a/setup-git
+++ b/setup-git
@@ -5,6 +5,7 @@ vared -p 'Enter your e-mail (john@johndoe.com): ' -c email &&
 git config --global user.email $email;
 git config --global pull.ff "only";
 git config --global core.pager bat; # is installed via brew install bat
+git config --global init.defaultBranch main
 ssh-keygen -t ed25519 -C $email;
 eval "$(ssh-agent -s)";
 echo "Host *\n    AddKeysToAgent yes\n    UseKeychain yes\n    IdentityFile ~/.ssh/id_ed25519" > ~/.ssh/config;


### PR DESCRIPTION
This PR removes node from brew install and instead introduces [fnm](https://github.com/Schniz/fnm) which is a more modern variant of nvm which I personally dislike.

fnm now always installs the latest LTS version of node.